### PR TITLE
FIT-11741 Exclude zxing lib

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -15,3 +15,7 @@ android {
         exclude 'META-INF/LICENSE'
     }
 }
+
+configurations {
+    compile.exclude group: 'com.google.zxing'
+}


### PR DESCRIPTION
Użycie nowej wersji pluginu https://github.com/phonegap/phonegap-plugin-barcodescanner

Fix na konflikt z pluginem do facebooka (https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/535#issuecomment-518626750)

https://fitatu.atlassian.net/browse/FIT-11741